### PR TITLE
Versiontesting

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,5 @@
+# Development
+
 ## Development install
 
 1. Clone this repo in your development environment
@@ -6,9 +8,13 @@
 
 ## Updating composer dependencies
 
-If you're in a local branch of this package and getting problems with `kontenta/kontour`
+- `composer update --prefer-lowest` can be used before running tests for testing backwards compatibility.
+- `composer show -D -o` can be used to check how far behind latest version the currently installed dependencies are.
+- `composer update` will install the latest versions of dependencies.
+
+If you're in a branch of this package and getting problems with `kontenta/kontour`
 requiring some specific version of this package you can add that version temporarily in `composer.json`
-like this:
+like this (make sure to remove this line before commiting):
 
 ```json
 "version": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
   },
   "require-dev": {
     "kontenta/kontour": "dev-master",
-    "orchestra/testbench": "~3.5",
-    "orchestra/testbench-dusk": "~3.5.5",
+    "orchestra/testbench": "^3.5",
+    "orchestra/testbench-dusk": "^3.5.5",
     "phpunit/phpunit": ">6.5",
     "laravel/dusk": ">2.0.13"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,14 @@
   "license": "MIT",
   "require": {
     "php": ">=7.0.0",
-    "laravel/framework": "~5.5"
+    "laravel/framework": "5.5.*|5.6.*"
   },
   "require-dev": {
     "kontenta/kontour": "dev-master",
-    "orchestra/testbench": "^3.5",
-    "orchestra/testbench-dusk": "^3.5"
+    "orchestra/testbench": "~3.5",
+    "orchestra/testbench-dusk": "~3.5.5",
+    "phpunit/phpunit": ">6.5",
+    "laravel/dusk": ">2.0.13"
   },
   "autoload": {
     "psr-4": {
@@ -28,8 +30,7 @@
       "providers": [
         "Kontenta\\KontourSupport\\KontourServiceProvider"
       ],
-      "aliases": {
-      }
+      "aliases": {}
     }
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require-dev": {
     "kontenta/kontour": "dev-master",
     "orchestra/testbench": "^3.5",
-    "orchestra/testbench-dusk": "^3.5.5",
+    "orchestra/testbench-dusk": "^3.5.5|3.6.x-dev",
     "phpunit/phpunit": ">6.5",
     "laravel/dusk": ">2.0.13"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         beStrictAboutTestSize="true"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
@@ -23,7 +22,7 @@
   <logging>
     <log type="tap" target="build/report.tap"/>
     <log type="junit" target="build/report.junit.xml"/>
-    <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+    <log type="coverage-html" target="build/coverage"/>
     <log type="coverage-text" target="build/coverage.txt"/>
     <log type="coverage-clover" target="build/logs/clover.xml"/>
   </logging>


### PR DESCRIPTION
This sets dependency versions so that `composer update` will use Laravel 5.6 (up from 5.5).

`composer update --prefer-lowest` will install Laravel 5.5 for testing the lower end.

`composer test` works after running both commands.